### PR TITLE
Packet cleanup

### DIFF
--- a/examples/publish.go
+++ b/examples/publish.go
@@ -1,0 +1,49 @@
+/*
+This example publishes a message to a given topic
+
+to run: go run ./examples/publish.go
+
+The default broker is the publicly available server hosted by the Eclipse foundation, but can be changed by specifying a
+different host name or IP address with the -server flag.
+
+To change the topic and message, use the -topic and -message flags, respectively.
+*/
+
+package main
+
+import (
+	"flag"
+	"github.com/andschneider/goqtt"
+	"log"
+	"net"
+)
+
+func main() {
+	server := flag.String("server", "mqtt.eclipse.org", "Server to connect to.")
+	port := flag.String("port", "1883", "Port of host.")
+	topic := flag.String("topic", "hello/world", "Topic(s) to subscribe to.")
+	message := flag.String("message", "hello", "Message to send to topic.")
+	verbose := flag.Bool("v", false, "Verbose output. Default is false.")
+	flag.Parse()
+
+	conn, err := net.Dial("tcp", *server+":"+*port)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	err = goqtt.SendConnect(conn, *verbose)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	log.Printf("connected to %s:%s\n", *server, *port)
+
+	// create publish packet
+	err = goqtt.SendPublish(conn, *topic, *message, *verbose)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	log.Printf("sent message: '%s' to topic: %s\n", *message, *topic)
+}

--- a/goqtt.go
+++ b/goqtt.go
@@ -2,6 +2,7 @@ package goqtt
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/andschneider/goqtt/packets"
 	"log"
 	"net"
@@ -16,6 +17,17 @@ func sendPacket(c net.Conn, packet []byte, verbose bool) {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func SendPublish(c net.Conn, topic string, message string, verbose bool) error {
+	buf := new(bytes.Buffer)
+	ppack := packets.CreatePublishPacket(topic, message)
+	err := ppack.Write(buf, verbose)
+	if err != nil {
+		return fmt.Errorf("could not write the publish packet: %v", err)
+	}
+	sendPacket(c, buf.Bytes(), verbose)
+	return nil
 }
 
 // SendPing is a helper function to create a Ping and send it right away.

--- a/goqtt.go
+++ b/goqtt.go
@@ -3,17 +3,19 @@ package goqtt
 import (
 	"bytes"
 	"fmt"
-	"github.com/andschneider/goqtt/packets"
 	"log"
 	"net"
 	"time"
+
+	"github.com/andschneider/goqtt/packets"
 )
 
-func sendPacket(c net.Conn, packet []byte, verbose bool) error {
+func sendPacket(c net.Conn, packet []byte) error {
 	_, err := c.Write(packet)
-	if verbose {
-		log.Printf("sent packet: %b", packet)
-	}
+	// TODO not sure if I want this yet
+	//if verbose {
+	//	log.Printf("sent packet: %08b", packet)
+	//}
 	if err != nil {
 		return fmt.Errorf("could not send packet to connection: %v", err)
 	}
@@ -27,13 +29,17 @@ func SendPublish(c net.Conn, topic string, message string, verbose bool) error {
 	// create packet
 	buf := new(bytes.Buffer)
 	ppack := packets.CreatePublishPacket(topic, message)
-	err := ppack.Write(buf, verbose)
+	err := ppack.Write(buf)
+	if verbose {
+		fmt.Printf("publish bytes : %v\n", buf.Bytes())
+		fmt.Printf("publish string: %v\n", &ppack)
+	}
 	if err != nil {
 		return fmt.Errorf("could not write PUBLISH packet: %v", err)
 	}
 
 	// send packet
-	err = sendPacket(c, buf.Bytes(), verbose)
+	err = sendPacket(c, buf.Bytes())
 	if err != nil {
 		return fmt.Errorf("could not send PUBLISH packet: %v", err)
 	}
@@ -48,13 +54,17 @@ func SendPing(c net.Conn, verbose bool) error {
 	// create packet
 	buf := new(bytes.Buffer)
 	ping := packets.CreatePingReqPacket()
-	err := ping.Write(buf, verbose)
+	err := ping.Write(buf)
+	if verbose {
+		fmt.Printf("ping bytes : %v\n", buf.Bytes())
+		fmt.Printf("ping string: %v\n", &ping)
+	}
 	if err != nil {
 		return fmt.Errorf("could not write PING packet: %v", err)
 	}
 
 	// send packet
-	err = sendPacket(c, buf.Bytes(), verbose)
+	err = sendPacket(c, buf.Bytes())
 	if err != nil {
 		return fmt.Errorf("could not send PING packet: %v", err)
 	}
@@ -76,13 +86,17 @@ func SendConnect(c net.Conn, verbose bool) error {
 	// create packet
 	buf := new(bytes.Buffer)
 	cpack := packets.CreateConnectPacket()
-	err := cpack.Write(buf, verbose)
+	err := cpack.Write(buf)
+	if verbose {
+		fmt.Printf("connect bytes : %v\n", buf.Bytes())
+		fmt.Printf("connect string: %v\n", &cpack)
+	}
 	if err != nil {
 		return fmt.Errorf("could not write CONNECT packet: %v", err)
 	}
 
 	// send packet
-	err = sendPacket(c, buf.Bytes(), verbose)
+	err = sendPacket(c, buf.Bytes())
 	if err != nil {
 		return fmt.Errorf("could not send CONNECT packet: %v", err)
 	}
@@ -101,13 +115,17 @@ func SendSubscribe(c net.Conn, topic string, verbose bool) error {
 	// create packet
 	buf := new(bytes.Buffer)
 	spack := packets.CreateSubscribePacket(topic)
-	err := spack.Write(buf, verbose)
+	err := spack.Write(buf)
+	if verbose {
+		fmt.Printf("subscribe bytes : %v\n", buf.Bytes())
+		fmt.Printf("subscribe string: %v\n", &spack)
+	}
 	if err != nil {
 		return fmt.Errorf("could not write SUBSCRIBE packet: %v", err)
 	}
 
 	// send packet
-	err = sendPacket(c, buf.Bytes(), verbose)
+	err = sendPacket(c, buf.Bytes())
 	if err != nil {
 		return fmt.Errorf("could not send SUBSCRIBE packet: %v", err)
 	}

--- a/goqtt.go
+++ b/goqtt.go
@@ -72,7 +72,7 @@ func SendPing(c net.Conn, verbose bool) error {
 	// response
 	// why did i make this a goroutine?
 	go func() {
-		_, err = packets.Reader(c)
+		err = packets.Reader(c)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -102,7 +102,7 @@ func SendConnect(c net.Conn, verbose bool) error {
 	}
 
 	// response
-	_, err = packets.Reader(c)
+	err = packets.Reader(c)
 	if err != nil {
 		log.Fatal(err)
 		return err
@@ -130,7 +130,7 @@ func SendSubscribe(c net.Conn, topic string, verbose bool) error {
 		return fmt.Errorf("could not send SUBSCRIBE packet: %v", err)
 	}
 	// response
-	_, err = packets.Reader(c)
+	err = packets.Reader(c)
 	if err != nil {
 		log.Fatal(err)
 		return err
@@ -161,7 +161,7 @@ func SubscribeLoop(conn net.Conn) {
 	for {
 		//log.Println("start loop")
 		// TODO add callback function to process packet from Reader
-		_, err := packets.Reader(conn)
+		err := packets.Reader(conn)
 		if err != nil {
 			log.Fatal(err)
 			return

--- a/packets/packet_connack.go
+++ b/packets/packet_connack.go
@@ -11,13 +11,18 @@ type ConnackPacket struct {
 	ReturnCode     byte
 }
 
+var connackType = PacketType{
+	name:     "CONNACK",
+	packetId: 32,
+}
+
 func (c *ConnackPacket) String() string {
 	return fmt.Sprintf("%v sessionpresent: %d returncode: %d", c.FixedHeader, c.SessionPresent, c.ReturnCode)
 }
 
 func (c *ConnackPacket) ReadConnackPacket(r io.Reader) error {
 	var fh FixedHeader
-	fh.MessageType = "CONNACK"
+	fh.PacketType = connackType
 	err := fh.read(r)
 	if err != nil {
 		return err

--- a/packets/packet_connack_test.go
+++ b/packets/packet_connack_test.go
@@ -6,11 +6,16 @@ import (
 	"testing"
 )
 
+const (
+	remainingLength = 2
+	sessionPresent  = 0
+	returnCode      = 0
+)
+
+var testConnackPacket = []byte{byte(remainingLength), byte(sessionPresent), byte(returnCode)}
+
 func TestConnackPacket(t *testing.T) {
-	remainingLength := 2
-	sessionPresent := 0
-	returnCode := 0
-	connack := bytes.NewBuffer([]byte{byte(remainingLength), byte(sessionPresent), byte(returnCode)})
+	connack := bytes.NewBuffer(testConnackPacket)
 
 	ca := ConnackPacket{}
 	err := ca.ReadConnackPacket(connack)
@@ -18,4 +23,29 @@ func TestConnackPacket(t *testing.T) {
 		t.Errorf("could not read connack packet: %v\n", err)
 	}
 	fmt.Printf("connack packet: %s\n", &ca)
+}
+
+func TestConnackPacket_Write(t *testing.T) {
+	connack := bytes.NewBuffer(testConnackPacket)
+
+	// correct packet
+	ca := ConnackPacket{}
+	err := ca.ReadConnackPacket(connack)
+	if err != nil {
+		t.Errorf("could not read connack packet: %v\n", err)
+	}
+	fmt.Printf("connack packet: %s\n", &ca)
+
+	// create packet
+	var buf bytes.Buffer
+	cp := CreateConnackPacket()
+	err = cp.Write(&buf)
+	if err != nil {
+		t.Errorf("could not write CONNACK packet: %v", err)
+	}
+	fmt.Printf("connack packet: %s\n", &cp)
+
+	if cp != ca {
+		t.Errorf("connack packets don't match")
+	}
 }

--- a/packets/packet_connack_test.go
+++ b/packets/packet_connack_test.go
@@ -17,5 +17,5 @@ func TestConnackPacket(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not read connack packet: %v\n", err)
 	}
-	fmt.Println(ca)
+	fmt.Printf("connack packet: %s\n", &ca)
 }

--- a/packets/packet_connect.go
+++ b/packets/packet_connect.go
@@ -19,6 +19,10 @@ type ConnectPacket struct {
 	ClientIdentifier string
 }
 
+func (c *ConnectPacket) String() string {
+	return fmt.Sprintf("%v protocolversion: %v connectflags: %08b clientid: %s", c.FixedHeader, c.ProtocolVersion, c.ConnectFlags, c.ClientIdentifier)
+}
+
 func CreateConnectPacket() (cp ConnectPacket) {
 	cp.FixedHeader = FixedHeader{MessageType: "CONNECT"}
 	cp.ProtocolName = []byte{0, 4, 77, 81, 84, 84} // "04MQTT"
@@ -40,8 +44,8 @@ func (c *ConnectPacket) Write(w io.Writer, v bool) error {
 	body.Write(c.KeepAlive)
 	body.Write(encodeString(c.ClientIdentifier))
 
-	c.FixedHeader.RemainingLength = body.Len()
-	packet := c.FixedHeader.WriteHeader()
+	c.RemainingLength = body.Len()
+	packet := c.WriteHeader()
 	packet.Write(body.Bytes())
 
 	if v {

--- a/packets/packet_connect.go
+++ b/packets/packet_connect.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
+	"time"
 )
 
 type ConnectPacket struct {
@@ -22,7 +25,8 @@ func CreateConnectPacket() (cp ConnectPacket) {
 	cp.ProtocolVersion = MQTT3
 	cp.ConnectFlags = 2
 	cp.KeepAlive = []byte{0, 60}
-	cp.ClientIdentifier = "andrew"
+	hostname, _ := os.Hostname()
+	cp.ClientIdentifier = hostname + strconv.Itoa(time.Now().Second())
 	return
 }
 

--- a/packets/packet_connect.go
+++ b/packets/packet_connect.go
@@ -19,12 +19,17 @@ type ConnectPacket struct {
 	ClientIdentifier string
 }
 
+var connectType = PacketType{
+	name:     "CONNECT",
+	packetId: 16,
+}
+
 func (c *ConnectPacket) String() string {
 	return fmt.Sprintf("%v protocolversion: %v connectflags: %08b clientid: %s", c.FixedHeader, c.ProtocolVersion, c.ConnectFlags, c.ClientIdentifier)
 }
 
 func CreateConnectPacket() (cp ConnectPacket) {
-	cp.FixedHeader = FixedHeader{MessageType: "CONNECT"}
+	cp.FixedHeader = FixedHeader{PacketType: connectType}
 	cp.ProtocolName = []byte{0, 4, 77, 81, 84, 84} // "04MQTT"
 	cp.ProtocolVersion = MQTT3
 	cp.ConnectFlags = 2

--- a/packets/packet_connect.go
+++ b/packets/packet_connect.go
@@ -34,7 +34,7 @@ func CreateConnectPacket() (cp ConnectPacket) {
 	return
 }
 
-func (c *ConnectPacket) Write(w io.Writer, v bool) error {
+func (c *ConnectPacket) Write(w io.Writer) error {
 	var body bytes.Buffer
 	var err error
 
@@ -47,11 +47,6 @@ func (c *ConnectPacket) Write(w io.Writer, v bool) error {
 	c.RemainingLength = body.Len()
 	packet := c.WriteHeader()
 	packet.Write(body.Bytes())
-
-	if v {
-		fmt.Println("BODY", body)
-		fmt.Println("PACKET", packet)
-	}
 	_, err = packet.WriteTo(w)
 
 	return err

--- a/packets/packet_connect_test.go
+++ b/packets/packet_connect_test.go
@@ -9,7 +9,7 @@ import (
 func TestConnectPacket(t *testing.T) {
 	var buf bytes.Buffer
 	cp := CreateConnectPacket()
-	err := cp.Write(&buf, true)
+	err := cp.Write(&buf)
 	if err != nil {
 		t.Errorf("could not write CONNECT packet: %v", err)
 	}

--- a/packets/packet_connect_test.go
+++ b/packets/packet_connect_test.go
@@ -1,13 +1,17 @@
 package packets
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 	"testing"
 )
 
 func TestConnectPacket(t *testing.T) {
+	var buf bytes.Buffer
 	cp := CreateConnectPacket()
-	cp.Write(os.Stdout, true)
-	fmt.Println()
+	err := cp.Write(&buf, true)
+	if err != nil {
+		t.Errorf("could not write CONNECT packet: %v", err)
+	}
+	fmt.Printf("connect packet: %s\n", &cp)
 }

--- a/packets/packet_disconnect.go
+++ b/packets/packet_disconnect.go
@@ -1,0 +1,42 @@
+package packets
+
+import (
+	"fmt"
+	"io"
+)
+
+type DisconnectPacket struct {
+	FixedHeader
+}
+
+var disconnectType = PacketType{
+	name:     "DISCONNECT",
+	packetId: 224,
+}
+
+func (d *DisconnectPacket) String() string {
+	return fmt.Sprintf("%v", d.FixedHeader)
+}
+
+func CreateDisconnectPacket() (d DisconnectPacket) {
+	d.FixedHeader = FixedHeader{PacketType: disconnectType, RemainingLength: 0}
+	return
+}
+
+func (d *DisconnectPacket) Write(w io.Writer) error {
+	packet := d.WriteHeader()
+	_, err := packet.WriteTo(w)
+	return err
+}
+
+func (d *DisconnectPacket) ReadDisconnectPacket(r io.Reader) error {
+	var fh FixedHeader
+	fh.PacketType = disconnectType
+	err := fh.read(r)
+	if err != nil {
+		return err
+	}
+	d.FixedHeader = fh
+
+	return nil
+}

--- a/packets/packet_disconnect_test.go
+++ b/packets/packet_disconnect_test.go
@@ -1,0 +1,43 @@
+package packets
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestDisconnectPacket_ReadDisconnectPacket(t *testing.T) {
+	disconnect := bytes.NewBuffer([]byte{0})
+
+	d := DisconnectPacket{}
+	err := d.ReadDisconnectPacket(disconnect)
+	if err != nil {
+		t.Errorf("could not read %s packet: %v\n", d.name, err)
+	}
+	fmt.Printf("%s packet: %s\n", d.name, &d)
+}
+
+func TestDisconnectPacket_Write(t *testing.T) {
+	disconnect := bytes.NewBuffer([]byte{0})
+
+	// correct packet
+	d := DisconnectPacket{}
+	err := d.ReadDisconnectPacket(disconnect)
+	if err != nil {
+		t.Errorf("could not read %s packet: %v\n", d.name, err)
+	}
+	fmt.Printf("%s packet: %s\n", d.name, &d)
+
+	// create packet
+	var buf bytes.Buffer
+	dp := CreateDisconnectPacket()
+	err = dp.Write(&buf)
+	if err != nil {
+		t.Errorf("could not write %s packet: %v", dp.name, err)
+	}
+	fmt.Printf("%s packet: %s\n", dp.name, &dp)
+
+	if dp != d {
+		t.Errorf("%s packets don't match\n", dp.name)
+	}
+}

--- a/packets/packet_pingreq.go
+++ b/packets/packet_pingreq.go
@@ -18,11 +18,8 @@ func CreatePingReqPacket() (pp PingReqPacket) {
 	return
 }
 
-func (pp *PingReqPacket) Write(w io.Writer, v bool) error {
-	packet := pp.FixedHeader.WriteHeader()
-	if v {
-		fmt.Println("PACKET", packet)
-	}
+func (pp *PingReqPacket) Write(w io.Writer) error {
+	packet := pp.WriteHeader()
 	_, err := packet.WriteTo(w)
 	return err
 }

--- a/packets/packet_pingreq.go
+++ b/packets/packet_pingreq.go
@@ -9,12 +9,17 @@ type PingReqPacket struct {
 	FixedHeader
 }
 
+var pingReqType = PacketType{
+	name:     "PINGREQ",
+	packetId: 192,
+}
+
 func (pp *PingReqPacket) String() string {
 	return fmt.Sprintf("%v", pp.FixedHeader)
 }
 
 func CreatePingReqPacket() (pp PingReqPacket) {
-	pp.FixedHeader = FixedHeader{MessageType: "PINGREQ", RemainingLength: 0}
+	pp.FixedHeader = FixedHeader{PacketType: pingReqType, RemainingLength: 0}
 	return
 }
 

--- a/packets/packet_pingreq.go
+++ b/packets/packet_pingreq.go
@@ -9,13 +9,17 @@ type PingReqPacket struct {
 	FixedHeader
 }
 
+func (pp *PingReqPacket) String() string {
+	return fmt.Sprintf("%v", pp.FixedHeader)
+}
+
 func CreatePingReqPacket() (pp PingReqPacket) {
 	pp.FixedHeader = FixedHeader{MessageType: "PINGREQ", RemainingLength: 0}
 	return
 }
 
-func (p *PingReqPacket) Write(w io.Writer, v bool) error {
-	packet := p.FixedHeader.WriteHeader()
+func (pp *PingReqPacket) Write(w io.Writer, v bool) error {
+	packet := pp.FixedHeader.WriteHeader()
 	if v {
 		fmt.Println("PACKET", packet)
 	}

--- a/packets/packet_pingreq_test.go
+++ b/packets/packet_pingreq_test.go
@@ -9,7 +9,7 @@ import (
 func TestPingReqPacket(t *testing.T) {
 	var buf bytes.Buffer
 	pr := CreatePingReqPacket()
-	err := pr.Write(&buf, true)
+	err := pr.Write(&buf)
 	if err != nil {
 		t.Errorf("could not write PingReq packet %v", err)
 	}

--- a/packets/packet_pingreq_test.go
+++ b/packets/packet_pingreq_test.go
@@ -1,16 +1,17 @@
 package packets
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 	"testing"
 )
 
 func TestPingReqPacket(t *testing.T) {
+	var buf bytes.Buffer
 	pr := CreatePingReqPacket()
-	err := pr.Write(os.Stdout, true)
+	err := pr.Write(&buf, true)
 	if err != nil {
 		t.Errorf("could not write PingReq packet %v", err)
 	}
-	fmt.Println()
+	fmt.Printf("pingreq packet: %s\n", &pr)
 }

--- a/packets/packet_pingresp.go
+++ b/packets/packet_pingresp.go
@@ -14,6 +14,10 @@ func CreatePingRespPacket() (pp PingRespPacket) {
 	return
 }
 
+func (p *PingRespPacket) String() string {
+	return fmt.Sprintf("%v", p.FixedHeader)
+}
+
 func (p *PingRespPacket) Write(w io.Writer, v bool) error {
 	packet := p.FixedHeader.WriteHeader()
 	if v {

--- a/packets/packet_pingresp.go
+++ b/packets/packet_pingresp.go
@@ -9,13 +9,18 @@ type PingRespPacket struct {
 	FixedHeader
 }
 
-func CreatePingRespPacket() (pp PingRespPacket) {
-	pp.FixedHeader = FixedHeader{MessageType: "PINGRESP"}
-	return
+var pingRespType = PacketType{
+	name:     "PINGRESP",
+	packetId: 208,
 }
 
 func (p *PingRespPacket) String() string {
 	return fmt.Sprintf("%v", p.FixedHeader)
+}
+
+func CreatePingRespPacket() (pp PingRespPacket) {
+	pp.FixedHeader = FixedHeader{PacketType: pingRespType}
+	return
 }
 
 func (p *PingRespPacket) Write(w io.Writer) error {
@@ -26,7 +31,7 @@ func (p *PingRespPacket) Write(w io.Writer) error {
 
 func (p *PingRespPacket) ReadPingRespPacket(r io.Reader) error {
 	var fh FixedHeader
-	fh.MessageType = "PINGRESP"
+	fh.PacketType = pingRespType
 	err := fh.read(r)
 	if err != nil {
 		return err

--- a/packets/packet_pingresp.go
+++ b/packets/packet_pingresp.go
@@ -18,11 +18,8 @@ func (p *PingRespPacket) String() string {
 	return fmt.Sprintf("%v", p.FixedHeader)
 }
 
-func (p *PingRespPacket) Write(w io.Writer, v bool) error {
-	packet := p.FixedHeader.WriteHeader()
-	if v {
-		fmt.Println("PACKET", packet)
-	}
+func (p *PingRespPacket) Write(w io.Writer) error {
+	packet := p.WriteHeader()
 	_, err := packet.WriteTo(w)
 	return err
 }

--- a/packets/packet_pingresp_test.go
+++ b/packets/packet_pingresp_test.go
@@ -1,16 +1,17 @@
 package packets
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 	"testing"
 )
 
 func TestPingRespPacket(t *testing.T) {
+	var buf bytes.Buffer
 	pr := CreatePingRespPacket()
-	err := pr.Write(os.Stdout, true)
+	err := pr.Write(&buf, true)
 	if err != nil {
-		t.Errorf("could not write PingReq packet %v", err)
+		t.Errorf("could not write PingResp packet %v", err)
 	}
-	fmt.Println()
+	fmt.Printf("pingresp packet: %s\n", &pr)
 }

--- a/packets/packet_pingresp_test.go
+++ b/packets/packet_pingresp_test.go
@@ -9,7 +9,7 @@ import (
 func TestPingRespPacket(t *testing.T) {
 	var buf bytes.Buffer
 	pr := CreatePingRespPacket()
-	err := pr.Write(&buf, true)
+	err := pr.Write(&buf)
 	if err != nil {
 		t.Errorf("could not write PingResp packet %v", err)
 	}

--- a/packets/packet_publish.go
+++ b/packets/packet_publish.go
@@ -17,7 +17,7 @@ func CreatePublishPacket(topic string, message string) (pp PublishPacket) {
 	pp.FixedHeader = FixedHeader{MessageType: "PUBLISH"}
 	pp.Topic = topic
 	pp.MessageId = []byte{0, 1}
-	pp.Message = encodeString(message)
+	pp.Message = []byte(message)
 	return
 }
 
@@ -31,6 +31,7 @@ func (p *PublishPacket) Write(w io.Writer, v bool) error {
 	p.FixedHeader.RemainingLength = body.Len() + len(p.Message)
 	packet := p.FixedHeader.WriteHeader()
 	packet.Write(body.Bytes())
+	//fmt.Printf("%x", p.Message)
 	packet.Write(p.Message)
 
 	if v {

--- a/packets/packet_publish.go
+++ b/packets/packet_publish.go
@@ -13,6 +13,10 @@ type PublishPacket struct {
 	Message   []byte
 }
 
+func (p *PublishPacket) String() string {
+	return fmt.Sprintf("%v topic: %s messageid: %v message: %s", p.FixedHeader, p.Topic, p.MessageId, p.Message)
+}
+
 func CreatePublishPacket(topic string, message string) (pp PublishPacket) {
 	pp.FixedHeader = FixedHeader{MessageType: "PUBLISH"}
 	pp.Topic = topic

--- a/packets/packet_publish.go
+++ b/packets/packet_publish.go
@@ -13,12 +13,17 @@ type PublishPacket struct {
 	Message   []byte
 }
 
+var publishType = PacketType{
+	name:     "PUBLISH",
+	packetId: 48,
+}
+
 func (p *PublishPacket) String() string {
 	return fmt.Sprintf("%v topic: %s messageid: %v message: %s", p.FixedHeader, p.Topic, p.MessageId, p.Message)
 }
 
 func CreatePublishPacket(topic string, message string) (pp PublishPacket) {
-	pp.FixedHeader = FixedHeader{MessageType: "PUBLISH"}
+	pp.FixedHeader = FixedHeader{PacketType: publishType}
 	pp.Topic = topic
 	pp.MessageId = []byte{0, 1}
 	pp.Message = []byte(message)

--- a/packets/packet_publish_test.go
+++ b/packets/packet_publish_test.go
@@ -14,6 +14,7 @@ func TestPublishPacket_Write(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not write Publish packet %v", err)
 	}
+	fmt.Printf("publish packet: %s\n", &pp)
 
 	packetType, err := decodeByte(&buf)
 	if err != nil {

--- a/packets/packet_publish_test.go
+++ b/packets/packet_publish_test.go
@@ -28,7 +28,7 @@ func TestPublishPacket_Write(t *testing.T) {
 	if topic != testTopic {
 		t.Errorf("topics do not match. expected %s, got %s", testTopic, topic)
 	}
-	ms := string(p.Message[2:]) // TODO not sure about the first two characters
+	ms := string(p.Message)
 	if ms != message {
 		t.Errorf("messages do not match. expected %s, got %s", message, ms)
 	}

--- a/packets/packet_publish_test.go
+++ b/packets/packet_publish_test.go
@@ -10,7 +10,7 @@ func TestPublishPacket_Write(t *testing.T) {
 	message := "hello world"
 	pp := CreatePublishPacket(testTopic, message)
 	var buf bytes.Buffer
-	err := pp.Write(&buf, true)
+	err := pp.Write(&buf)
 	if err != nil {
 		t.Errorf("could not write Publish packet %v", err)
 	}

--- a/packets/packet_suback.go
+++ b/packets/packet_suback.go
@@ -11,13 +11,18 @@ type SubackPacket struct {
 	ReturnCodes []byte
 }
 
+var subackType = PacketType{
+	name:     "SUBACK",
+	packetId: 144,
+}
+
 func (sa *SubackPacket) String() string {
 	return fmt.Sprintf("%v messageid: %d", sa.FixedHeader, sa.MessageId)
 }
 
 func (sa *SubackPacket) ReadSubackPacket(r io.Reader) error {
 	var fh FixedHeader
-	fh.MessageType = "SUBACK"
+	fh.PacketType = subackType
 	err := fh.read(r)
 	if err != nil {
 		return err

--- a/packets/packet_suback_test.go
+++ b/packets/packet_suback_test.go
@@ -16,5 +16,5 @@ func TestSubackPacket(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not read suback packet: %v\n", err)
 	}
-	fmt.Println(sa)
+	fmt.Printf("subscribe packet: %s\n", &sa)
 }

--- a/packets/packet_suback_test.go
+++ b/packets/packet_suback_test.go
@@ -6,15 +6,46 @@ import (
 	"testing"
 )
 
+var testSubackPacket = []byte{3, 0, 1, 0}
+
 func TestSubackPacket(t *testing.T) {
-	// TODO this packet isn't totally right
-	suback := bytes.NewBuffer([]byte{144, 3, 0, 1, 0})
-	fmt.Printf("%08b\n", suback)
+	suback := bytes.NewBuffer(testSubackPacket)
 
 	sa := SubackPacket{}
 	err := sa.ReadSubackPacket(suback)
 	if err != nil {
 		t.Errorf("could not read suback packet: %v\n", err)
 	}
-	fmt.Printf("subscribe packet: %s\n", &sa)
+	fmt.Printf("suback packet: %s\n", &sa)
+}
+
+func TestSubackPacket_Write(t *testing.T) {
+	suback := bytes.NewBuffer(testSubackPacket)
+
+	sa := SubackPacket{}
+	err := sa.ReadSubackPacket(suback)
+	if err != nil {
+		t.Errorf("could not read suback packet: %v\n", err)
+	}
+	fmt.Printf("read suback packet:  %s\n", &sa)
+
+	// create packet
+	var buf bytes.Buffer
+	sp := CreateSubackPacket()
+	err = sp.Write(&buf)
+	if err != nil {
+		t.Errorf("could not write suback packet: %v", err)
+	}
+	fmt.Printf("write suback packet: %s\n", &sp)
+
+	// verify they match
+	if !bytes.Equal(sp.MessageId, sa.MessageId) {
+		t.Errorf("suback messageids don't match")
+	}
+	if !bytes.Equal(sp.ReturnCodes, sa.ReturnCodes) {
+		t.Errorf("suback returncodes don't match")
+	}
+	if sp.FixedHeader != sa.FixedHeader {
+		t.Errorf("suback fixedheaders don't match")
+	}
 }

--- a/packets/packet_subscribe.go
+++ b/packets/packet_subscribe.go
@@ -25,7 +25,7 @@ func CreateSubscribePacket(topic string) (sp SubscribePacket) {
 	return
 }
 
-func (s *SubscribePacket) Write(w io.Writer, v bool) error {
+func (s *SubscribePacket) Write(w io.Writer) error {
 	var body bytes.Buffer
 	var err error
 
@@ -35,14 +35,9 @@ func (s *SubscribePacket) Write(w io.Writer, v bool) error {
 		body.WriteByte(s.Qos[i])
 	}
 
-	s.FixedHeader.RemainingLength = body.Len()
-	packet := s.FixedHeader.WriteHeader()
+	s.RemainingLength = body.Len()
+	packet := s.WriteHeader()
 	packet.Write(body.Bytes())
-
-	if v {
-		fmt.Println("BODY", body)
-		fmt.Println("PACKET", packet)
-	}
 	_, err = packet.WriteTo(w)
 
 	return err

--- a/packets/packet_subscribe.go
+++ b/packets/packet_subscribe.go
@@ -13,6 +13,10 @@ type SubscribePacket struct {
 	Qos       []byte
 }
 
+func (s *SubscribePacket) String() string {
+	return fmt.Sprintf("%v messageid: %v topics: %s", s.FixedHeader, s.MessageId, s.Topics)
+}
+
 func CreateSubscribePacket(topic string) (sp SubscribePacket) {
 	sp.FixedHeader = FixedHeader{MessageType: "SUBSCRIBE"}
 	sp.MessageId = []byte{0, 1}

--- a/packets/packet_subscribe.go
+++ b/packets/packet_subscribe.go
@@ -13,12 +13,17 @@ type SubscribePacket struct {
 	Qos       []byte
 }
 
+var subscribeType = PacketType{
+	name:     "SUBSCRIBE",
+	packetId: 130,
+}
+
 func (s *SubscribePacket) String() string {
 	return fmt.Sprintf("%v messageid: %v topics: %s", s.FixedHeader, s.MessageId, s.Topics)
 }
 
 func CreateSubscribePacket(topic string) (sp SubscribePacket) {
-	sp.FixedHeader = FixedHeader{MessageType: "SUBSCRIBE"}
+	sp.FixedHeader = FixedHeader{PacketType: subscribeType}
 	sp.MessageId = []byte{0, 1}
 	sp.Topics = []string{topic}
 	sp.Qos = []byte{0}

--- a/packets/packet_subscribe_test.go
+++ b/packets/packet_subscribe_test.go
@@ -1,14 +1,17 @@
 package packets
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 	"testing"
 )
 
 func TestSubscribePacket(t *testing.T) {
+	var buf bytes.Buffer
 	sp := CreateSubscribePacket(testTopic)
-	// fmt.Println(sp)
-	sp.Write(os.Stdout, true)
-	fmt.Println()
+	err := sp.Write(&buf, true)
+	if err != nil {
+		t.Errorf("could not write SUBSCRIBE packet: %v", err)
+	}
+	fmt.Printf("subscribe packet: %s\n", &sp)
 }

--- a/packets/packet_subscribe_test.go
+++ b/packets/packet_subscribe_test.go
@@ -9,7 +9,7 @@ import (
 func TestSubscribePacket(t *testing.T) {
 	var buf bytes.Buffer
 	sp := CreateSubscribePacket(testTopic)
-	err := sp.Write(&buf, true)
+	err := sp.Write(&buf)
 	if err != nil {
 		t.Errorf("could not write SUBSCRIBE packet: %v", err)
 	}

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -55,7 +55,6 @@ func (fh *FixedHeader) WriteHeader() (header bytes.Buffer) {
 }
 
 func (fh *FixedHeader) read(r io.Reader) (err error) {
-	//fh.MessageType = "PUBLISH" // TODO generalize to different types
 	fh.RemainingLength, err = decodeLength(r)
 	return err
 }

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -75,7 +75,7 @@ func Reader(r io.Reader) error {
 		if err != nil {
 			return fmt.Errorf("could not read SUBACK packet: %v", err)
 		}
-		//log.Printf("suback packet: %v", sp)
+		//log.Printf("suback packet: %v\n", &sp)
 	}
 	return nil
 }
@@ -150,6 +150,16 @@ func decodeBytes(b io.Reader) ([]byte, error) {
 	}
 
 	return field, nil
+}
+
+func decodeMessageId(b io.Reader) ([]byte, error) {
+	var bb []byte
+	num := make([]byte, 2)
+	_, err := b.Read(num)
+	if err != nil {
+		return nil, err
+	}
+	return append(bb, num...), nil
 }
 
 func decodeUint16(b io.Reader) (uint16, error) {

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -13,7 +13,7 @@ func TestFixedHeader(t *testing.T) {
 	var expected bytes.Buffer
 	expected.Write([]byte{16, 0})
 
-	fh := FixedHeader{MessageType: "CONNECT"}
+	fh := FixedHeader{PacketType: connectType}
 	h := fh.WriteHeader()
 	if !bytes.Equal(expected.Bytes(), h.Bytes()) {
 		t.Errorf("Expected %b, got %b\n", expected, h)


### PR DESCRIPTION
Large update to the packets. 

- Made sure all packets have read and write methods
- Removed verbose parameter from all write methods
- Made sure all packets fulfill the Stringer interface
- Added a PacketType struct instead of using a map - holds packet name and header byte
- Added Disconnect packet