### PR TITLE
Remove packet channel

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strconv"
 	"time"
-
-	"github.com/andschneider/goqtt/packets"
 )
 
 // Default values for the Client configuration. See the DefaultClientId function for
@@ -35,8 +33,6 @@ type clientConfig struct {
 type Client struct {
 	Config *clientConfig
 	conn   net.Conn
-
-	send chan packets.Packet
 }
 
 // NewClient creates a Client struct which can be used to interact with a MQTT broker.
@@ -64,7 +60,6 @@ func NewClient(addr string, opts ...option) *Client {
 // DefaultClientId creates a default value for the Client's clientId.
 // It uses the process id and the current time to try to prevent client collisions with the broker.
 func DefaultClientId() string {
-	// create a default ClientId based on time to reduce collisions in the broker
 	cid := fmt.Sprintf("%s-%d-%s", "goqtt", os.Getpid(), strconv.Itoa(time.Now().Second()))
 	return cid
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,10 +1,7 @@
-package goqtt_test
+package goqtt
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/andschneider/goqtt"
 )
 
 const (
@@ -16,21 +13,41 @@ const (
 )
 
 func TestNewClientConfig_Default(t *testing.T) {
-	c := goqtt.NewClient(server)
+	c := NewClient(server)
 
-	err := c.Connect()
-	if err != nil {
-		t.Fatal(err)
+	if c.Config.topic != DefaultTopic {
+		t.Fatalf("default topic error. got %s, want %s", c.Config.topic, DefaultTopic)
+	}
+	if c.Config.port != DefaultPort {
+		t.Fatalf("default port error. got %s, want %s", c.Config.port, DefaultPort)
+	}
+	if c.Config.keepAlive != DefaultKeepAlive {
+		t.Fatalf("default keep alive error. got %d, want %d", c.Config.keepAlive, DefaultKeepAlive)
 	}
 }
 
 func TestOptions(t *testing.T) {
-	cid := goqtt.ClientId(clientID)
-	ka := goqtt.KeepAlive(keepAlive)
-	port := goqtt.Port(port)
-	topic := goqtt.Topic(topic)
+	// set config options
+	cid := ClientId(clientID)
+	ka := KeepAlive(keepAlive)
+	p := Port(port)
+	tp := Topic(topic)
 
-	c := goqtt.NewClient("test", cid, port, topic, ka)
+	c := NewClient(server, cid, p, tp, ka)
 
-	fmt.Printf("%+v\n", c.Config)
+	if c.Config.clientId != clientID {
+		t.Fatalf("keep alive. got %s, want %s", c.Config.clientId, clientID)
+	}
+	if c.Config.keepAlive != keepAlive {
+		t.Fatalf("keep alive. got %d, want %d", c.Config.keepAlive, keepAlive)
+	}
+	if c.Config.port != port {
+		t.Fatalf("port error. got %s, want %s", c.Config.port, port)
+	}
+	if c.Config.topic != topic {
+		t.Fatalf("topic error. got %s, want %s", c.Config.topic, topic)
+	}
+	if c.Config.server != server {
+		t.Fatalf("server error. got %s, want %s", c.Config.server, server)
+	}
 }

--- a/ping.go
+++ b/ping.go
@@ -14,14 +14,14 @@ func (c *Client) SendPing() error {
 	var p packets.PingReqPacket
 	p.CreatePacket()
 
-	err := p.Write(c.conn)
+	err := c.sendPacket(&p)
 	if err != nil {
 		return fmt.Errorf("could not write Ping packet: %v", err)
 	}
 	return nil
 }
 
-// keepAlive is an unsophisticated way to prevent the server from closing the client's connection.
+// keepAlivePing is an unsophisticated way to prevent the server from closing the client's connection.
 // It blindly sends a Ping packet according to the client's configured KeepAlive setting. This
 // is possibly wasteful as Pings only need to be sent if no other Packets have been sent in the
 // time specified by the KeepAlive. More sophisticated timing logic could be added later.

--- a/publish.go
+++ b/publish.go
@@ -12,10 +12,7 @@ func (c *Client) SendPublish(message string) error {
 	var p packets.PublishPacket
 	p.CreatePublishPacket(c.Config.topic, message)
 
-	// TODO review this
-	// Write directly to connection instead of sending packet to client's connection channel to avoid
-	// race conditions if the SendPublish command happens towards the end of a script.
-	err := p.Write(c.conn)
+	err := c.sendPacket(&p)
 	if err != nil {
 		return fmt.Errorf("could not write Publish packet: %v", err)
 	}

--- a/subscribe.go
+++ b/subscribe.go
@@ -16,7 +16,10 @@ func (c *Client) Subscribe() error {
 	var p packets.SubscribePacket
 	p.CreateSubscribePacket(c.Config.topic)
 
-	c.stagePacket(&p)
+	err := c.sendPacket(&p)
+	if err != nil {
+		return fmt.Errorf("could not write Subscribe packet: %v", err)
+	}
 
 	// read response and verify it's a SUBACK packet
 	r, err := c.readResponse()
@@ -40,7 +43,10 @@ func (c *Client) Unsubscribe() error {
 	var p packets.UnsubscribePacket
 	p.CreateUnsubscribePacket(c.Config.topic)
 
-	c.stagePacket(&p)
+	err := c.sendPacket(&p)
+	if err != nil {
+		return fmt.Errorf("could not write Unsubscribe packet: %v", err)
+	}
 
 	// read response and verify it's a UNSUBACK packet
 	r, err := c.readResponse()


### PR DESCRIPTION
Making a PR for this commit because I might want to come back to it later. Not totally sure about concurrency in Go yet.

I don't think using a channel to send packets had any benefit. In fact, I think it could probably have introduced some race conditions for reading from the TCP connection if multiple packets were sent at the same time. (since the read was always executed right after the packet was sent to the channel, if two packets were sent at the same time the reads could get mixed up)