### PR TITLE
Make connect flags more explicit

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -44,6 +44,10 @@ func (c *Client) Connect() error {
 		typeErrorResponseLogger(cp.Name(), r.Name(), r)
 		return fmt.Errorf("did not receive a CONNACK packet, got %s instead", r.Name())
 	}
+
+	// start a keepAlive process which will send Ping packets to prevent a disconnect
+	// TODO I don't think this should be called in here - should be a background thing for a Client
+	go c.keepAlivePing()
 	return nil
 }
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -31,9 +31,6 @@ func (c *Client) Subscribe() error {
 		return fmt.Errorf("did not receive a SUBACK packet, got %s instead", r.Name())
 	}
 
-	// start a keepAlive process which will send Ping packets to prevent a disconnect
-	// TODO I don't think this should be called in here - should be a background thing for a Client
-	go c.keepAlivePing()
 	return nil
 }
 


### PR DESCRIPTION
Instead of just having a "2" for the connect flags I made it defined as a function. This should make it more clear what is being used now, and also make i easier to add more options later.